### PR TITLE
Bumped spellcheck action to latest version, since 0.22.1 is EOL

### DIFF
--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@v3
-    - uses: rojopolis/spellcheck-github-actions@0.22.1
+    - uses: rojopolis/spellcheck-github-actions@0.35.0
       name: Spellcheck
       with:
         config_path: .github/workflows/config/.spellConfig.yml # put path to configuration file here


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am _sunsetting_ version 0.22.1 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.35.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can see that you are using [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, does the set up not work for you? - should should have received several PRs for updates of the action I maintain and possibly others.

jonasbn